### PR TITLE
Rename to `sync-child-process`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/sync-process'"
+    if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/sync-child-process'"
     needs: [static_analysis, tests]
 
     steps:
@@ -65,7 +65,7 @@ jobs:
 
   typedoc:
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/sync-process'"
+    if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/sync-child-process'"
     needs: [deploy]
 
     environment:

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# `sync-process`
+# `sync-child-process`
 
-This package exposes a `SyncProcess` class that allows Node.js to run
-a subprocess synchronously *and* interactively.
+This package exposes a `SyncChildProcess` class that allows Node.js to run a
+subprocess synchronously *and* interactively.
 
 ## Usage
 
-Use `new SyncProcess()` to start running a subprocess. This supports the same
-API as [`child_process.spawn()`] other than a few options. You can send input to
-the process using `process.stdin`, and receive events from it (stdout, stderr,
-or exit) using `process.next()`. This implements [the iterator protocol], but
-*not* the iterable protocol because it's intrinsically stateful.
+Use `new SyncChildProcess()` to start running a subprocess. This supports the
+same API as [`child_process.spawn()`] other than a few options. You can send
+input to the process using `process.stdin`, and receive events from it (stdout,
+stderr, or exit) using `process.next()`. This implements [the iterator
+protocol], but *not* the iterable protocol because it's intrinsically stateful.
 
 [the iterator protocol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol
 [`child_process.spawn()`]: https://nodejs.org/api/child_process.html#child_processspawncommand-args-options
 
 ```js
-import {SyncProcess} from 'sync-process';
+import {SyncChildProcess} from 'sync-child-process';
 // or
-// const {SyncProcess} = require('sync-process');
+// const {SyncChildProcess} = require('sync-child-process');
 
-const node = new SyncProcess('node', ['--interactive']);
+const node = new SyncChildProcess('node', ['--interactive']);
 
 for (;;) {
   if (node.next().value.data.toString().endsWith('> ')) break;

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -5,9 +5,9 @@
 import * as fs from 'fs';
 import * as p from 'path';
 
-import {ExitEvent, StderrEvent, StdoutEvent, SyncProcess} from './index';
+import {ExitEvent, StderrEvent, StdoutEvent, SyncChildProcess} from './index';
 
-describe('SyncProcess', () => {
+describe('SyncChildProcess', () => {
   describe('stdio', () => {
     it('emits stdout', () => {
       withJSProcess('console.log("hello, world!");', node => {
@@ -70,7 +70,7 @@ describe('SyncProcess', () => {
 
   it('passes options to the subprocess', () => {
     withJSFile('console.log(process.env.SYNC_PROCESS_TEST);', file => {
-      const node = new SyncProcess(process.argv0, [file], {
+      const node = new SyncChildProcess(process.argv0, [file], {
         env: {...process.env, SYNC_PROCESS_TEST: 'abcdef'},
       });
       expectStdout(node.next(), 'abcdef\n');
@@ -134,15 +134,15 @@ function expectExit(
 }
 
 /**
- * Starts a `SyncProcess` running a JS file with the given `contents` and passes
- * it to `callback`.
+ * Starts a `SyncChildProcess` running a JS file with the given `contents` and
+ * passes it to `callback`.
  */
 function withJSProcess(
   contents: string,
-  callback: (process: SyncProcess) => void,
+  callback: (process: SyncChildProcess) => void,
 ): void {
   return withJSFile(contents, file => {
-    const node = new SyncProcess(process.argv0, [file]);
+    const node = new SyncChildProcess(process.argv0, [file]);
 
     try {
       callback(node);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -30,7 +30,7 @@ function isMarkedAsUntransferable(object: unknown): boolean {
  * A child process that runs synchronously while also allowing the user to
  * interact with it before it shuts down.
  */
-export class SyncProcess
+export class SyncChildProcess
   implements Iterator<StderrEvent | StdoutEvent, ExitEvent | undefined>
 {
   /** The port that communicates with the worker thread. */

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "sync-process",
+  "name": "sync-child-process",
   "version": "1.0.0",
   "description": "Run a subprocess synchronously and interactively in Node.js",
-  "repository": "sass/sync-process",
+  "repository": "sass/sync-child-process",
   "author": "Google Inc.",
   "license": "MIT",
   "exports": {


### PR DESCRIPTION
It turns out `sync-process` already exists, it's just a security
placeholder because it used to by malicious so it doesn't show up on
npm search.